### PR TITLE
Add support for other Flex extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,11 @@
                 ],
                 "extensions": [
                     ".l",
-		    ".flex",
+                    ".ll",
+                    ".l++",
+                    ".lxx",
+                    ".lpp",
+                    ".flex"
                 ],
                 "configuration": "./language-configuration.json"
             },


### PR DESCRIPTION
Added `.lpp` to list of recognized Flex input file extensions, added others according to [this page](https://www.gnu.org/software/automake/manual/html_node/Yacc-and-Lex.html).