### PR TITLE
Fix a few parsing bugs with the Yacc parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "lex-flex-yacc-bison",
     "displayName": "Lex Flex Yacc Bison",
     "description": "Language support for Lex, Flex, Yacc and Bison.",
-    "version": "0.0.2",
+    "version": "0.0.3",
     "publisher": "faustinoaq",
     "icon": "images/icon.png",
     "license": "MIT",

--- a/syntaxes/yacc.json
+++ b/syntaxes/yacc.json
@@ -159,6 +159,9 @@
       },
       "patterns": [
         {
+          "include": "source.c#comments"
+        },
+        {
           "include": "#grammar.after"
         },
         {
@@ -175,6 +178,9 @@
       },
       "end": ";",
       "patterns": [
+        {
+          "include": "source.c#comments"
+        },
         {
           "include": "#rule.code"
         },

--- a/syntaxes/yacc.json
+++ b/syntaxes/yacc.json
@@ -158,7 +158,7 @@
       ]
     },
     "rule": {
-      "begin": "(_?[\\w\\-_]*[\\w\\d\\-_]\\w*):",
+      "begin": "([\\w\\-_][\\w\\d\\-_]*)([ ]*):",
       "beginCaptures": {
         "1": {
           "name": "variable.language.yacc"

--- a/syntaxes/yacc.json
+++ b/syntaxes/yacc.json
@@ -31,6 +31,12 @@
     "injected.cpp": {
       "patterns": [
         {
+          "include": "#special_identifiers"
+        },
+        {
+          "include": "#integers"
+        },
+        {
           "include": "source.cpp"
         }
       ]
@@ -81,6 +87,9 @@
     "special_identifiers": {
       "match": "[@$](\\d+|\\$)",
       "name": "support.variable.yacc"
+    },
+    "integers": {
+        "match": "(-?[0-9]+)"
     },
     "grammar.before": {
       "patterns": [

--- a/syntaxes/yacc.json
+++ b/syntaxes/yacc.json
@@ -114,7 +114,15 @@
           "name": "punctuation.separator.tag.section.yacc"
         }
       },
-      "name": "cpp.yacc"
+      "name": "source.cpp",
+      "patterns": [
+        {
+          "include": "#integers"
+        },
+        {
+          "include": "source.cpp"
+        }
+      ]
     },
     "options": {
       "patterns": [
@@ -209,7 +217,15 @@
           "name": "keyword.source.yacc"
         }
       },
-      "name": "cpp.yacc"
+      "name": "source.cpp",
+      "patterns": [
+        {
+          "include": "#integers"
+        },
+        {
+          "include": "source.cpp"
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
This pull request contains a few commits that each fix a few issues with the Yacc parser, namely:

1. Allow the parser to recognize rules with trailing whitespace
2. Fixed a parsing error that was stopping all parsing for lines that contained isolated integers
3. Correctly parse C-style comments everywhere they are allowed (this wasn't happening due to missing rules in the grammar)

The second to last commit of this PR also fixes an error introduced by the previous fixes in that special identifiers like $$ and $1 were being incorrectly recognized as special identifiers in standard C/C++ code, i.e., outside of a rule's code.

Finally, the last commit also bumps the package version.